### PR TITLE
Update domainthrottlemap.php

### DIFF
--- a/plugins/domainthrottlemap.php
+++ b/plugins/domainthrottlemap.php
@@ -112,6 +112,7 @@ class domainthrottlemap extends phplistPlugin {
 			case 'tuaw.com':
 			case 'uvaol.com.br':
 			case 'vemashe.com':
+			case 'verizon.net':
 			case 'weblogsinc.com':
 			case 'wild4music.com':
 			case 'wmconnect.com':


### PR DESCRIPTION
Verizon is now part of AOL and they also changed their MX records to AOL. 

This change was brought to you by [Online Email Extractor](https://www.onlineemailextractor.com)